### PR TITLE
Bugfix/toggle tick sounds played at same time

### DIFF
--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -174,8 +174,8 @@ class gb_EventHandler : EventHandler
 
       switch (input)
       {
-      case InputSelectNextWeapon: toggleWeapons(); selectNextWeapon(); return true;
-      case InputSelectPrevWeapon: toggleWeapons(); selectPrevWeapon(); return true;
+      case InputSelectNextWeapon: toggleWeapons(); selectNextWeapon(false); return true;
+      case InputSelectPrevWeapon: toggleWeapons(); selectPrevWeapon(false); return true;
       }
     }
 
@@ -319,17 +319,17 @@ class gb_EventHandler : EventHandler
   }
 
   private ui
-  void selectNextWeapon()
+  void selectNextWeapon(bool withTickSound = true)
   {
     bool success = mWeaponMenu.selectNextWeapon();
-    if (success) mSounds.playTick();
+    if (success && withTickSound) mSounds.playTick();
   }
 
   private ui
-  void selectPrevWeapon()
+  void selectPrevWeapon(bool withTickSound = true)
   {
     bool success = mWeaponMenu.selectPrevWeapon();
-    if (success) mSounds.playTick();
+    if (success && withTickSound) mSounds.playTick();
   }
 
   private ui

--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -109,15 +109,15 @@ class gb_EventHandler : EventHandler
     {
       switch (input)
       {
-      case InputSelectNextWeapon: mWeaponMenu.selectNextWeapon(); mWheelController.reset(); break;
-      case InputSelectPrevWeapon: mWeaponMenu.selectPrevWeapon(); mWheelController.reset(); break;
+      case InputSelectNextWeapon: selectNextWeapon(); mWheelController.reset(); break;
+      case InputSelectPrevWeapon: selectPrevWeapon(); mWheelController.reset(); break;
       case InputConfirmSelection: confirmSelection(); close(); break;
       case InputClose:            close(); break;
 
       default:
         if (!gb_Input.isSlot(input)) return false;
         mWheelController.reset();
-        mWeaponMenu.selectSlot(gb_Input.getSlot(input));
+        selectWeaponSlot(gb_Input.getSlot(input));
         break;
       }
 
@@ -154,10 +154,10 @@ class gb_EventHandler : EventHandler
 
         if (mOptions.isNoMenuIfOne() && mWeaponMenu.isOneWeaponInSlot(slot))
         {
-          mWeaponMenu.selectSlot(slot);
+          selectWeaponSlot(slot);
           gb_Sender.sendSelectEvent(mWeaponMenu.confirmSelection());
         }
-        else if (mWeaponMenu.selectSlot(slot))
+        else if (selectWeaponSlot(slot))
         {
           mSounds.playToggle();
           mActivity.openWeapons();
@@ -174,8 +174,8 @@ class gb_EventHandler : EventHandler
 
       switch (input)
       {
-      case InputSelectNextWeapon: toggleWeapons(); mWeaponMenu.selectNextWeapon(); return true;
-      case InputSelectPrevWeapon: toggleWeapons(); mWeaponMenu.selectPrevWeapon(); return true;
+      case InputSelectNextWeapon: toggleWeapons(); selectNextWeapon(); return true;
+      case InputSelectPrevWeapon: toggleWeapons(); selectPrevWeapon(); return true;
       }
     }
 
@@ -234,7 +234,10 @@ class gb_EventHandler : EventHandler
       mWheelIndexer.update(viewModel, controllerModel);
       int selectedViewIndex = mWheelIndexer.getSelectedIndex();
 
-      if (mActivity.isWeapons()) mWeaponMenu.setSelectedIndexFromView(viewModel, selectedViewIndex);
+      if (mActivity.isWeapons()) {
+        bool success = mWeaponMenu.setSelectedIndexFromView(viewModel, selectedViewIndex);
+        if (success) mSounds.playTick();
+      } 
       else if (mActivity.isInventory()) mInventoryMenu.setSelectedIndex(selectedViewIndex);
 
       if (selectedViewIndex != -1) viewModel.selectedIndex = selectedViewIndex;
@@ -313,6 +316,29 @@ class gb_EventHandler : EventHandler
 
     mSounds.playToggle();
     mActivity.openInventory();
+  }
+
+  private ui
+  void selectNextWeapon()
+  {
+    bool success = mWeaponMenu.selectNextWeapon();
+    if (success) mSounds.playTick();
+  }
+
+  private ui
+  void selectPrevWeapon()
+  {
+    bool success = mWeaponMenu.selectPrevWeapon();
+    if (success) mSounds.playTick();
+  }
+
+  private ui
+  bool selectWeaponSlot(int slot)
+  {
+    bool success = mWeaponMenu.selectSlot(slot);
+    if (success) mSounds.playTick();
+
+    return success;
   }
 
   private clearscope

--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -109,15 +109,15 @@ class gb_EventHandler : EventHandler
     {
       switch (input)
       {
-      case InputSelectNextWeapon: selectNextWeapon(); mWheelController.reset(); break;
-      case InputSelectPrevWeapon: selectPrevWeapon(); mWheelController.reset(); break;
+      case InputSelectNextWeapon: tickIf(mWeaponMenu.selectNextWeapon()); mWheelController.reset(); break;
+      case InputSelectPrevWeapon: tickIf(mWeaponMenu.selectPrevWeapon()); mWheelController.reset(); break;
       case InputConfirmSelection: confirmSelection(); close(); break;
       case InputClose:            close(); break;
 
       default:
         if (!gb_Input.isSlot(input)) return false;
         mWheelController.reset();
-        selectWeaponSlot(gb_Input.getSlot(input));
+        tickIf(mWeaponMenu.selectSlot(gb_Input.getSlot(input)));
         break;
       }
 
@@ -154,10 +154,10 @@ class gb_EventHandler : EventHandler
 
         if (mOptions.isNoMenuIfOne() && mWeaponMenu.isOneWeaponInSlot(slot))
         {
-          selectWeaponSlot(slot);
+          tickIf(mWeaponMenu.selectSlot(slot));
           gb_Sender.sendSelectEvent(mWeaponMenu.confirmSelection());
         }
-        else if (selectWeaponSlot(slot, false))
+        else if (mWeaponMenu.selectSlot(slot))
         {
           mSounds.playToggle();
           mActivity.openWeapons();
@@ -174,8 +174,8 @@ class gb_EventHandler : EventHandler
 
       switch (input)
       {
-      case InputSelectNextWeapon: toggleWeapons(); selectNextWeapon(false); return true;
-      case InputSelectPrevWeapon: toggleWeapons(); selectPrevWeapon(false); return true;
+      case InputSelectNextWeapon: toggleWeapons(); mWeaponMenu.selectNextWeapon(); return true;
+      case InputSelectPrevWeapon: toggleWeapons(); mWeaponMenu.selectPrevWeapon(); return true;
       }
     }
 
@@ -234,10 +234,7 @@ class gb_EventHandler : EventHandler
       mWheelIndexer.update(viewModel, controllerModel);
       int selectedViewIndex = mWheelIndexer.getSelectedIndex();
 
-      if (mActivity.isWeapons()) {
-        bool success = mWeaponMenu.setSelectedIndexFromView(viewModel, selectedViewIndex);
-        if (success) mSounds.playTick();
-      } 
+      if (mActivity.isWeapons()) tickIf(mWeaponMenu.setSelectedIndexFromView(viewModel, selectedViewIndex));
       else if (mActivity.isInventory()) mInventoryMenu.setSelectedIndex(selectedViewIndex);
 
       if (selectedViewIndex != -1) viewModel.selectedIndex = selectedViewIndex;
@@ -286,6 +283,12 @@ class gb_EventHandler : EventHandler
   }
 
   private ui
+  void tickIf(bool mustTick)
+  {
+    if (mustTick) mSounds.playTick();
+  }
+
+  private ui
   void toggleWeapons()
   {
     if (mActivity.isWeapons()) close();
@@ -316,29 +319,6 @@ class gb_EventHandler : EventHandler
 
     mSounds.playToggle();
     mActivity.openInventory();
-  }
-
-  private ui
-  void selectNextWeapon(bool withTickSound = true)
-  {
-    bool success = mWeaponMenu.selectNextWeapon();
-    if (success && withTickSound) mSounds.playTick();
-  }
-
-  private ui
-  void selectPrevWeapon(bool withTickSound = true)
-  {
-    bool success = mWeaponMenu.selectPrevWeapon();
-    if (success && withTickSound) mSounds.playTick();
-  }
-
-  private ui
-  bool selectWeaponSlot(int slot, bool withTickSound = true)
-  {
-    bool success = mWeaponMenu.selectSlot(slot);
-    if (success && withTickSound) mSounds.playTick();
-
-    return success;
   }
 
   private clearscope

--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -387,7 +387,7 @@ class gb_EventHandler : EventHandler
     gb_CustomWeaponOrderStorage.reset(mWeaponSetHash);
     gb_WeaponData weaponData;
     gb_WeaponDataLoader.load(weaponData);
-    mWeaponMenu = gb_WeaponMenu.from(weaponData, mOptions, mSounds);
+    mWeaponMenu = gb_WeaponMenu.from(weaponData, mOptions);
   }
 
   private ui
@@ -460,7 +460,7 @@ class gb_EventHandler : EventHandler
     gb_WeaponData weaponData;
     gb_WeaponDataLoader.load(weaponData);
     mWeaponSetHash   = gb_CustomWeaponOrderStorage.calculateHash(weaponData);
-    mWeaponMenu      = gb_WeaponMenu.from(weaponData, mOptions, mSounds);
+    mWeaponMenu      = gb_WeaponMenu.from(weaponData, mOptions);
     gb_CustomWeaponOrderStorage.applyOperations(mWeaponSetHash, mWeaponMenu);
     mInventoryMenu   = gb_InventoryMenu.from(mSounds);
 

--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -157,7 +157,7 @@ class gb_EventHandler : EventHandler
           selectWeaponSlot(slot);
           gb_Sender.sendSelectEvent(mWeaponMenu.confirmSelection());
         }
-        else if (selectWeaponSlot(slot))
+        else if (selectWeaponSlot(slot, false))
         {
           mSounds.playToggle();
           mActivity.openWeapons();
@@ -333,10 +333,10 @@ class gb_EventHandler : EventHandler
   }
 
   private ui
-  bool selectWeaponSlot(int slot)
+  bool selectWeaponSlot(int slot, bool withTickSound = true)
   {
     bool success = mWeaponMenu.selectSlot(slot);
-    if (success) mSounds.playTick();
+    if (success && withTickSound) mSounds.playTick();
 
     return success;
   }

--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -442,7 +442,7 @@ class gb_EventHandler : EventHandler
     mWeaponSetHash   = gb_CustomWeaponOrderStorage.calculateHash(weaponData);
     mWeaponMenu      = gb_WeaponMenu.from(weaponData, mOptions);
     gb_CustomWeaponOrderStorage.applyOperations(mWeaponSetHash, mWeaponMenu);
-    mInventoryMenu   = gb_InventoryMenu.from(mSounds);
+    mInventoryMenu   = gb_InventoryMenu.from();
 
     mActivity        = gb_Activity.from();
     mFadeInOut       = gb_FadeInOut.from();

--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -127,8 +127,8 @@ class gb_EventHandler : EventHandler
     {
       switch (input)
       {
-      case InputSelectNextWeapon: mInventoryMenu.selectNext(); mWheelController.reset(); break;
-      case InputSelectPrevWeapon: mInventoryMenu.selectPrev(); mWheelController.reset(); break;
+      case InputSelectNextWeapon: tickIf(mInventoryMenu.selectNext()); mWheelController.reset(); break;
+      case InputSelectPrevWeapon: tickIf(mInventoryMenu.selectPrev()); mWheelController.reset(); break;
       case InputConfirmSelection: confirmSelection(); close(); break;
       case InputClose:            close(); break;
 
@@ -138,7 +138,7 @@ class gb_EventHandler : EventHandler
         mWheelController.reset();
         int slot = gb_Input.getSlot(input);
         int index = (slot == 0) ? 9 : slot - 1;
-        mInventoryMenu.setSelectedIndex(index);
+        tickIf(mInventoryMenu.setSelectedIndex(index));
         break;
       }
       }
@@ -235,7 +235,7 @@ class gb_EventHandler : EventHandler
       int selectedViewIndex = mWheelIndexer.getSelectedIndex();
 
       if (mActivity.isWeapons()) tickIf(mWeaponMenu.setSelectedIndexFromView(viewModel, selectedViewIndex));
-      else if (mActivity.isInventory()) mInventoryMenu.setSelectedIndex(selectedViewIndex);
+      else if (mActivity.isInventory()) tickIf(mInventoryMenu.setSelectedIndex(selectedViewIndex));
 
       if (selectedViewIndex != -1) viewModel.selectedIndex = selectedViewIndex;
 

--- a/zscript/gearbox/inventory_menu.zs
+++ b/zscript/gearbox/inventory_menu.zs
@@ -47,32 +47,35 @@ class gb_InventoryMenu
   }
 
   ui
-  void selectNext()
+  bool selectNext()
   {
     int nItems = getItemsNumber();
-    if (nItems == 0) return;
+    if (nItems == 0) return false;
 
-    mSounds.playTick();
     mSelectedIndex = (mSelectedIndex + 1) % nItems;
+
+    return true;
   }
 
   ui
-  void selectPrev()
+  bool selectPrev()
   {
     int nItems = getItemsNumber();
-    if (nItems == 0) return;
+    if (nItems == 0) return false;
 
-    mSounds.playTick();
     mSelectedIndex = (mSelectedIndex - 1 + nItems) % nItems;
+
+    return true;
   }
 
   ui
-  void setSelectedIndex(int index)
+  bool setSelectedIndex(int index)
   {
-    if (index == -1 || mSelectedIndex == index) return;
+    if (index == -1 || mSelectedIndex == index) return false;
 
-    mSounds.playTick();
     mSelectedIndex = index;
+
+    return true;
   }
 
   ui

--- a/zscript/gearbox/inventory_menu.zs
+++ b/zscript/gearbox/inventory_menu.zs
@@ -19,12 +19,11 @@ class gb_InventoryMenu
 {
 
   static
-  gb_InventoryMenu from(gb_Sounds sounds)
+  gb_InventoryMenu from()
   {
     let result = new("gb_InventoryMenu");
 
     result.mSelectedIndex = 0;
-    result.mSounds = sounds;
 
     return result;
   }
@@ -132,6 +131,5 @@ class gb_InventoryMenu
   }
 
   private int mSelectedIndex;
-  private gb_Sounds mSounds;
 
 } // class gb_InventoryMenu

--- a/zscript/gearbox/weapon_menu.zs
+++ b/zscript/gearbox/weapon_menu.zs
@@ -41,12 +41,12 @@ class gb_WeaponMenu
     return mSelectedIndex;
   }
 
-  void setSelectedIndexFromView(gb_ViewModel viewModel, int index)
+  bool setSelectedIndexFromView(gb_ViewModel viewModel, int index)
   {
-    if (index == -1 || mSelectedIndex == viewModel.indices[index]) return;
+    if (index == -1 || mSelectedIndex == viewModel.indices[index]) return false;
 
-    mSounds.playTick();
     mSelectedIndex = viewModel.indices[index];
+    return true;
   }
 
   void setSelectedWeapon(class<Weapon> aClass)
@@ -58,17 +58,17 @@ class gb_WeaponMenu
   }
 
   ui
-  void selectNextWeapon()
+  bool selectNextWeapon()
   {
     mSelectedIndex = findNextWeapon();
-    if (mSelectedIndex != mWeapons.size()) mSounds.playTick();
+    return mSelectedIndex != mWeapons.size();
   }
 
   ui
-  void selectPrevWeapon()
+  bool selectPrevWeapon()
   {
     mSelectedIndex = findPrevWeapon();
-    if (mSelectedIndex != mWeapons.size()) mSounds.playTick();
+    return mSelectedIndex != mWeapons.size();
   }
 
   bool selectSlot(int slot)
@@ -80,7 +80,6 @@ class gb_WeaponMenu
       if (mSlots[index] == slot && isInInventory(index) && !isHidden(mWeapons[index].getClassName()))
       {
         mSelectedIndex = index;
-        mSounds.playTick();
         return true;
       }
     }

--- a/zscript/gearbox/weapon_menu.zs
+++ b/zscript/gearbox/weapon_menu.zs
@@ -19,7 +19,7 @@ class gb_WeaponMenu
 {
 
   static
-  gb_WeaponMenu from(gb_WeaponData weaponData, gb_Options options, gb_Sounds sounds)
+  gb_WeaponMenu from(gb_WeaponData weaponData, gb_Options options)
   {
     let result = new("gb_WeaponMenu");
 
@@ -28,7 +28,6 @@ class gb_WeaponMenu
     result.mSelectedIndex = 0;
     result.mCacheTime     = 0;
     result.mOptions       = options;
-    result.mSounds        = sounds;
 
     loadIconServices(result.mIconServices);
     loadHideServices(result.mHideServices);
@@ -426,6 +425,5 @@ class gb_WeaponMenu
   private int          mCacheTime;
 
   private gb_Options mOptions;
-  private gb_Sounds  mSounds;
 
 } // class gb_WeaponMenu


### PR DESCRIPTION
This PR solves a bug by which both toggle and select (also named as tick) sounds are played at the same time when you open the weapons menu.

It contains, more specifically, the following changes:

- Refactored weapon_menu so it does not handle sounds. Now event_handler (its orchestrator) wiill be the only one coupled to the sound playing system.
- Solved the bug by which toggle and tick sounds were played at the same time when opening the weapon menu. It has been solved for all the following found situations: when pressing slot keys and when scrolling between weapons (and intercept next/prev weapon keys is activated in the options).

It remains as a TODO to check if the same is happening to the inventory system, which I haven't thoroughly checked, but it seems possible since its logic is very similar to the weapons one.

I've tried to respect the existing code style as much as possible by the way.