### PR TITLE
Now there is a code-wise difference between the open and close menu sounds

### DIFF
--- a/sndinfo.txt
+++ b/sndinfo.txt
@@ -1,5 +1,8 @@
 gearbox/tick sounds/gb_tick.ogg
 $volume gearbox/tick 0.5
 
-gearbox/toggle sounds/gb_toggle.ogg
-$volume gearbox/toggle 0.2
+gearbox/open sounds/gb_toggle.ogg
+$volume gearbox/open 0.2
+
+gearbox/close sounds/gb_toggle.ogg
+$volume gearbox/close 0.2

--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -159,7 +159,7 @@ class gb_EventHandler : EventHandler
         }
         else if (mWeaponMenu.selectSlot(slot))
         {
-          mSounds.playToggle();
+          mSounds.playOpen();
           mActivity.openWeapons();
         }
         else
@@ -308,7 +308,7 @@ class gb_EventHandler : EventHandler
     if (gb_Player.isDead()) return;
 
     mWeaponMenu.setSelectedWeapon(gb_WeaponWatcher.current());
-    mSounds.playToggle();
+    mSounds.playOpen();
     mActivity.openWeapons();
   }
 
@@ -317,14 +317,14 @@ class gb_EventHandler : EventHandler
   {
     if (gb_Player.isDead()) return;
 
-    mSounds.playToggle();
+    mSounds.playOpen();
     mActivity.openInventory();
   }
 
   private clearscope
   void close()
   {
-    mSounds.playToggle();
+    mSounds.playClose();
     mActivity.close();
   }
 

--- a/zscript/gearbox/sounds.zs
+++ b/zscript/gearbox/sounds.zs
@@ -31,9 +31,14 @@ class gb_Sounds
     playSound("gearbox/tick");
   }
 
-  void playToggle()
+  void playOpen()
   {
-    playSound("gearbox/toggle");
+    playSound("gearbox/open");
+  }
+
+  void playClose()
+  {
+    playSound("gearbox/close");
   }
 
 // private: ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adds the possibility to have different sound files for opening and closing the menus. This is very nice for making addons that alter these sounds and want to have different sounds for open and close.

Despite its simplicity, It has been thoroughly tested.