### PR TITLE
I fix a bug by which the inventory could be "invisibly" opened and closed when there were no items

### DIFF
--- a/zscript/gearbox/event_handler.zs
+++ b/zscript/gearbox/event_handler.zs
@@ -315,7 +315,7 @@ class gb_EventHandler : EventHandler
   private ui
   void openInventory()
   {
-    if (gb_Player.isDead()) return;
+    if (gb_Player.isDead() || gb_InventoryMenu.thereAreNoItems()) return;
 
     mSounds.playToggle();
     mActivity.openInventory();

--- a/zscript/gearbox/inventory_menu.zs
+++ b/zscript/gearbox/inventory_menu.zs
@@ -28,6 +28,12 @@ class gb_InventoryMenu
     return result;
   }
 
+  static
+  bool thereAreNoItems()
+  {
+    return getItemsNumber() == 0;
+  }
+
   string confirmSelection() const
   {
     let item  = players[consolePlayer].mo.inv;


### PR DESCRIPTION
Steps to reproduce:

- Assign a key for opening the inventory menu.
- Have 0 items in the game.
- Press the "open inventory" key. You can hear the "open sound", although the menu is not visible.
- If you select slot keys or try to scroll, you can hear the "tick sound", although the menu is not visible.
- If you press the open inventory key again, it will get closed.

In wheel mode, there is an empty wheel, but in blocks/text it is a bit more annoying since there is zero visual feedback.

After the fix, when you press the open inventory key and don't have items, it simply does not open.