### PR TITLE
Fix VM Abort when externalSelectedIndexInModel is not set

### DIFF
--- a/zscript/gearbox/wheel/indexer.zs
+++ b/zscript/gearbox/wheel/indexer.zs
@@ -48,7 +48,7 @@ class gb_WheelIndexer
       }
     }
 
-    if (!mMultiWheelMode.isEngaged(viewModel)) return externalSelectedIndexInModel;
+    if (externalSelectedIndexInModel < 0 || !mMultiWheelMode.isEngaged(viewModel)) return externalSelectedIndexInModel;
 
     gb_MultiWheelModel multiWheelModel;
     gb_MultiWheel.fill(viewModel, multiWheelModel);
@@ -85,6 +85,8 @@ class gb_WheelIndexer
         break;
       }
     }
+
+    if (externalSelectedIndexInModel < 0) return externalSelectedIndexInModel;
 
     int slot = viewModel.slots[externalSelectedIndexInModel];
 


### PR DESCRIPTION
This change simply adds some safety checks in the `getInnerIndex` and `getOuterIndex` methods and short-circuits them to simply return `UNDEFINED_INDEX` instead.  As shown below, the steps that recreated the issue before no longer cause a VM abort and the wheel renders as I'd expect:

![Screenshot_Doom_20230620_093651](https://github.com/mmaulwurff/gearbox/assets/6988914/b1ef657c-a929-4b98-8c69-ee20a3d381a7)

![Screenshot_Doom_20230620_093707](https://github.com/mmaulwurff/gearbox/assets/6988914/66dd8775-17a0-4e5a-96db-cec7c8124dc5)

![Screenshot_Doom_20230620_093715](https://github.com/mmaulwurff/gearbox/assets/6988914/f4843920-ce4c-4bf2-a071-76e628be5242)

Edit: Just to make sure, I tested adding one of the weapons in slot 2 into the backpack, and the subwheel collapsed as expected:

![Screenshot_Doom_20230620_094037](https://github.com/mmaulwurff/gearbox/assets/6988914/59e16eaf-f413-48db-a0e4-7596a87c0b12)

![Screenshot_Doom_20230620_094041](https://github.com/mmaulwurff/gearbox/assets/6988914/ac947dfa-96fa-4fb6-9b87-61f1b4554779)

Fixes #40